### PR TITLE
Fix vsock for Node.js and modernize interface

### DIFF
--- a/appfs/nodejs/.img-resize/Makefile
+++ b/appfs/nodejs/.img-resize/Makefile
@@ -13,7 +13,7 @@ output.ext4: node_modules image.js
 	rm -rf output.ext4 /tmp/lorem.out/
 	mkdir -p /tmp/lorem.out/
 	touch output.ext4
-	truncate -s 30M output.ext4
+	truncate -s 50M output.ext4
 	mkfs.ext4 output.ext4
 	sudo mount output.ext4 /tmp/lorem.out/
 	sudo cp -r node_modules workload image.js libertybell.jpg /tmp/lorem.out/

--- a/appfs/nodejs/.img-resize/package-lock.json
+++ b/appfs/nodejs/.img-resize/package-lock.json
@@ -13,22 +13,22 @@
       }
     },
     "@jimp/bmp": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
-      "integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.0.tgz",
+      "integrity": "sha512-lc4Ecyys6mRpKHLjFefkS1irCeIBTCpDBjKvNkU/6cIeIMXrFhv290MDT0WCL4UNFjJC/oU2PPraq+M+RkAcpA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "bmp-js": "^0.1.0"
       }
     },
     "@jimp/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-7WBYr3BX84fc9tuA86EDhAKNyT9QLcbVYk4whwvshxKtODPxlF1hmZU6Xmx2shoJ62JJtiWLsPsXAHKfEuERtQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "any-base": "^1.1.0",
         "buffer": "^5.2.0",
         "exif-parser": "^0.1.12",
@@ -41,293 +41,293 @@
       }
     },
     "@jimp/custom": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
-      "integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.0.tgz",
+      "integrity": "sha512-xN9WHeW2RP3gLdXdehCgnzKq8l9ezMsfWpkZP0HYtGqwGDSRXx+LNGR2Da1J/tV0pB+qbt67gAXtaxkJwdQ3cA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/core": "^0.14.0"
+        "@jimp/core": "^0.16.0"
       }
     },
     "@jimp/gif": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
-      "integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.0.tgz",
+      "integrity": "sha512-thc3C6/dvGKEVTMxiX82ruRAitIx7EstThqzrd0qk7Yf2O3qbrRZuENl6KNn2PXpmkr6fjcfFLWVM39bP4MG1Q==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "gifwrap": "^0.9.2",
         "omggif": "^1.0.9"
       }
     },
     "@jimp/jpeg": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
-      "integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.0.tgz",
+      "integrity": "sha512-pzlv92YZi7ySvIICNkB0eMphLztBcTAMH2kl5lxFMzF1FDv2FR2d/FI1ph6DSzBV8VYFDu4AM1lJRq3hFJurgQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "jpeg-js": "^0.4.0"
       }
     },
     "@jimp/plugin-blit": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
-      "integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.0.tgz",
+      "integrity": "sha512-CrakcEvr2ztOwECKpuwmwhXArbtDP2SB44WV0wrFXtuss2mkBbL/hIkUmTnLyJGpwIflj4Vww9m5yIreG5lgUQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-blur": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
-      "integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.0.tgz",
+      "integrity": "sha512-CfTrQR4JY+DGtGbdAbdZgbUpjOqtcF+kmGOoa1uh3NF16tn1glbE8/0SA9YkgvHxNTmekwuT7Lu0nRq09MKVJw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-circle": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
-      "integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.0.tgz",
+      "integrity": "sha512-O79288GKwUIxpHR3qyYg0paH/Iegz+Bdo2ePIvD/M3MigEzVdj5dJ/CQXz2cUnJx87rc0k1N5cTI4floIgv0tg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-color": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
-      "integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.0.tgz",
+      "integrity": "sha512-S4CbN1r5+VjUF9OBIyWxWBTXRNutLQqAAOkq7QX//lS4HY76eOAafgWWwZR7ci9WWZT8uyyw4tfd4ePoBvoYhw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "tinycolor2": "^1.4.1"
       }
     },
     "@jimp/plugin-contain": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
-      "integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.0.tgz",
+      "integrity": "sha512-ZAVe9ad0/TDLSPutIP/8Z+jXXOv638w/FZeA3avTAI5GfWV7ZBT6BB7kDI3iZTl+SHUjv/MlzHCS99WCnpc1hg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-cover": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
-      "integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.0.tgz",
+      "integrity": "sha512-gJGorvc4HOeSR0dNR29mYLLXtrWvgj8da0B/lUJSb0R2AvUrb+VgLKSfFPyf+nL/jtcm9/CJzYhAPcz13zmRKA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-crop": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
-      "integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.0.tgz",
+      "integrity": "sha512-I5McmdrNodg0iU815qOsuI8CjkwiRsFRTY4/LBOsLGHZasvxhzFxGcwD3SgnohdIkhRc3tX8jfvKg2pdPbD2AA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-displace": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
-      "integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.0.tgz",
+      "integrity": "sha512-+c5n5jDiN/neAuAxAAy55Gpycgmyay1PwUy8qKM1fgfBE874mrF5C4u1ThFz4OiDkRirKLpncRmrUMHa9boZtA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-dither": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
-      "integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.0.tgz",
+      "integrity": "sha512-rsLHSGnpWniQXoughYXRCbK/8KKXi+avV5z5mHIKzAKS4areXW03XlLqmy9o26q2h0g/YV5Hkxo9jwIw0v2Fpg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-fisheye": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
-      "integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.0.tgz",
+      "integrity": "sha512-P6KsHQHUOWyDprxKl4chPTwKIJNbXB7LGDQH6Bq/q8zZ9XwYXGnTmkHA/BwGKI6HGCj/+R2WoP3Cnhwm6XaIpg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-flip": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
-      "integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.0.tgz",
+      "integrity": "sha512-5MlqM1RJohk0NU0Z3ZtviI0DqHXDB0OuRk3dimUIquePz1OocFCt9Z4bBbDRIczGZFOrDrCrpHMfMxPjwm7eXw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-gaussian": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
-      "integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.0.tgz",
+      "integrity": "sha512-oP2Hg4gR4uq9id1gF+SfTvPrzqZc3fVY+t6gwxPXPgpnb9S5UVuSQbwtixY1EEBC9XRdX2XFko9eUul8dTnUpQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-invert": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
-      "integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.0.tgz",
+      "integrity": "sha512-RFsES55G7po6rv35A/3jz7IA1BOr8krX4H0zmtKUprcrhFl+El9iZojVCpJQRJ5QKQVS3iXi5H6EGN7AT1HykQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-mask": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
-      "integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.0.tgz",
+      "integrity": "sha512-inJweZgTNYZQdF0m5f/or5/LCLhpz4ccSDsK9HveuFQ82ITfJcvFaUlvlo11pHRl2r+Q92Er7B5g7icMIzXHZw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-normalize": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
-      "integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.0.tgz",
+      "integrity": "sha512-sfqhHDGks0ccqIaTCG/dFJ772eGi8bewxIvrQkeLw5TizzPZ3S+C4GXKwlkX2z5dyQr30cHM5Mv6+XhNNLEHWw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-print": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
-      "integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.0.tgz",
+      "integrity": "sha512-tQJfSOTf+las/PJpdUK9Aw9EdComQ50zl29TgMrAULuae1lh+e/A188ZhNQzTCpAAc/PEku8xoke+rYUU1AVig==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "load-bmfont": "^1.4.0"
       }
     },
     "@jimp/plugin-resize": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
-      "integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.0.tgz",
+      "integrity": "sha512-aI5H1Xe1fE1phBBI0EgQiVgMEXJ7cy2CXH+H7WSxnrdZJTnt9emzc4LnvKEOPBY6dCPw3P7k/BHp9SDTpUKSOQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-rotate": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
-      "integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.0.tgz",
+      "integrity": "sha512-YTKo4LntC2h46H6+De+3ctt8MacC+fTbIdw527BBBIKF44aWYn0uAQlAO+R+Aemnq4YqNnCnrZzPtWYZXA6nNw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-scale": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
-      "integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.0.tgz",
+      "integrity": "sha512-AfDnTIjBzGdvJ1K7MkUexgkGGAYDzpNzkYoCpfaRNKl/txoivaA6iKfvCiE7i1IDXq5mRCLkjQjMF43l8kwv5g==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-shadow": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
-      "integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.0.tgz",
+      "integrity": "sha512-8O1CKwvSnrrAIuAM3BEDTwt4U5oRVB5pXxnRegYXDuFFLDPIp2N4ILQqC2NaN+PBaVvj1JuLYuxmNzja0uRQKQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugin-threshold": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
-      "integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.0.tgz",
+      "integrity": "sha512-PNrB6IIF7kDGu7A/cyNAy3pchWtXbJGdpowkW6hcEzXOR+FwBRMuo5LS+q/eedo86qQ2F1vw5dm/nWYJxNxvkg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0"
+        "@jimp/utils": "^0.16.0"
       }
     },
     "@jimp/plugins": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
-      "integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.0.tgz",
+      "integrity": "sha512-aiyn/9MrSqVJwsnBmkbHD4DWTowULdP4NEes8Vt738KxZMw1UawKbEbj3/CzHIeEIQKjDECTi+jNd5HIbDq9LQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/plugin-blit": "^0.14.0",
-        "@jimp/plugin-blur": "^0.14.0",
-        "@jimp/plugin-circle": "^0.14.0",
-        "@jimp/plugin-color": "^0.14.0",
-        "@jimp/plugin-contain": "^0.14.0",
-        "@jimp/plugin-cover": "^0.14.0",
-        "@jimp/plugin-crop": "^0.14.0",
-        "@jimp/plugin-displace": "^0.14.0",
-        "@jimp/plugin-dither": "^0.14.0",
-        "@jimp/plugin-fisheye": "^0.14.0",
-        "@jimp/plugin-flip": "^0.14.0",
-        "@jimp/plugin-gaussian": "^0.14.0",
-        "@jimp/plugin-invert": "^0.14.0",
-        "@jimp/plugin-mask": "^0.14.0",
-        "@jimp/plugin-normalize": "^0.14.0",
-        "@jimp/plugin-print": "^0.14.0",
-        "@jimp/plugin-resize": "^0.14.0",
-        "@jimp/plugin-rotate": "^0.14.0",
-        "@jimp/plugin-scale": "^0.14.0",
-        "@jimp/plugin-shadow": "^0.14.0",
-        "@jimp/plugin-threshold": "^0.14.0",
+        "@jimp/plugin-blit": "^0.16.0",
+        "@jimp/plugin-blur": "^0.16.0",
+        "@jimp/plugin-circle": "^0.16.0",
+        "@jimp/plugin-color": "^0.16.0",
+        "@jimp/plugin-contain": "^0.16.0",
+        "@jimp/plugin-cover": "^0.16.0",
+        "@jimp/plugin-crop": "^0.16.0",
+        "@jimp/plugin-displace": "^0.16.0",
+        "@jimp/plugin-dither": "^0.16.0",
+        "@jimp/plugin-fisheye": "^0.16.0",
+        "@jimp/plugin-flip": "^0.16.0",
+        "@jimp/plugin-gaussian": "^0.16.0",
+        "@jimp/plugin-invert": "^0.16.0",
+        "@jimp/plugin-mask": "^0.16.0",
+        "@jimp/plugin-normalize": "^0.16.0",
+        "@jimp/plugin-print": "^0.16.0",
+        "@jimp/plugin-resize": "^0.16.0",
+        "@jimp/plugin-rotate": "^0.16.0",
+        "@jimp/plugin-scale": "^0.16.0",
+        "@jimp/plugin-shadow": "^0.16.0",
+        "@jimp/plugin-threshold": "^0.16.0",
         "timm": "^1.6.1"
       }
     },
     "@jimp/png": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
-      "integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.0.tgz",
+      "integrity": "sha512-3uDwCeZRaHTq6Jqjav37n73IGL4vrDkoHLzkC+dAGcSdaKnUnRxD/sO4CBTK1cHttJhsf5Xk/+0dO+qaqIEvNA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.14.0",
+        "@jimp/utils": "^0.16.0",
         "pngjs": "^3.3.3"
       }
     },
     "@jimp/tiff": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
-      "integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.0.tgz",
+      "integrity": "sha512-wiGgIKGtUwR7vUi+PHv7qzEKhlnqT/k78qtOgsF6PiGhXGevJWBIniD4LksbQaW+Ph1Jwl3ovvYEdS89Db46Bw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "utif": "^2.0.1"
       }
     },
     "@jimp/types": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
-      "integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.0.tgz",
+      "integrity": "sha512-T0VBF1HFXZ+Ez48zQ0sxrOpcFbfSzCulaVONWeEi/CqcNv2B7UmiaA81bw9uLGZ40VIOrFYHB20ma0m1asYBvw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/bmp": "^0.14.0",
-        "@jimp/gif": "^0.14.0",
-        "@jimp/jpeg": "^0.14.0",
-        "@jimp/png": "^0.14.0",
-        "@jimp/tiff": "^0.14.0",
+        "@jimp/bmp": "^0.16.0",
+        "@jimp/gif": "^0.16.0",
+        "@jimp/jpeg": "^0.16.0",
+        "@jimp/png": "^0.16.0",
+        "@jimp/tiff": "^0.16.0",
         "timm": "^1.6.1"
       }
     },
     "@jimp/utils": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
-      "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-dZJd5Rq4yOjPtqN/bArNy0v03nnaiHCf/Qct2wdiqK0k4wsfDL2Lle9XmswNcPPFuoL/LNnYY2E5ruAnatF/4A==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
@@ -411,14 +411,14 @@
       "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "jimp": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
-      "integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.0.tgz",
+      "integrity": "sha512-WRfGlXB6/0xY3mSoskfVhWVNSegVZCgmvunJDc41QthTWi5oRG2FeL7eOcX0zz/Z+dYRu6Q0ibO2yltC+EIptA==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/custom": "^0.14.0",
-        "@jimp/plugins": "^0.14.0",
-        "@jimp/types": "^0.14.0",
+        "@jimp/custom": "^0.16.0",
+        "@jimp/plugins": "^0.16.0",
+        "@jimp/types": "^0.16.0",
         "regenerator-runtime": "^0.13.3"
       }
     },

--- a/appfs/nodejs/.img-resize/package.json
+++ b/appfs/nodejs/.img-resize/package.json
@@ -10,9 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "jimp": "^0.14.0",
-    "jpeg-js": ">=0.4.0",
-    "minimist": ">=0.2.1",
+    "jimp": "^0.16.0",
     "node-zip": "^1.1.1"
   },
   "devDependencies": {}

--- a/appfs/nodejs/.img-resize/workload
+++ b/appfs/nodejs/.img-resize/workload
@@ -1,6 +1,6 @@
 const Image = require(`${__dirname}/image`);
 
-exports.handle = function(request, respond) {
+exports.handle = async function(request) {
     var i = new Image(`${__dirname}/libertybell.jpg`);
-    return i.generate().then((response) => respond(response));
+    return await i.generate();
 }

--- a/appfs/nodejs/lorem/workload
+++ b/appfs/nodejs/lorem/workload
@@ -1,8 +1,8 @@
 const { loremIpsum } = require('lorem-ipsum');
 
-exports.handle = function(request, respond) {
-  respond({
+exports.handle = async function(request) {
+  return {
     request: request,
     sentence: loremIpsum()
-  });
+  };
 }

--- a/appfs/nodejs/ocr/Makefile
+++ b/appfs/nodejs/ocr/Makefile
@@ -19,5 +19,5 @@ output.ext2: node_modules tesseract
 	truncate -s 200M output.ext2
 	mkfs.ext2 output.ext2
 	sudo mount output.ext2 /tmp/lorem.out/
-	sudo cp -r tesseract node_modules workload pitontable.png /tmp/lorem.out/
+	sudo cp -r tesseract node_modules workload linuxboot.png pitontable.png /tmp/lorem.out/
 	sudo umount /tmp/lorem.out/

--- a/appfs/nodejs/ocr/workload
+++ b/appfs/nodejs/ocr/workload
@@ -2,16 +2,18 @@ process.env.LD_LIBRARY_PATH=`${__dirname}/tesseract/lib`;
 process.env.TESSDATA_PREFIX=`${__dirname}/tesseract/share/tessdata`;
 const tesseract = require('tesseractocr');
 
-exports.handle = function(request, respond) {
+exports.handle = function(request) {
+  return new Promise((resolve, reject) => {
     tesseract.recognize(
         `${__dirname}/${request["img"]}`,
         {execPath: `${__dirname}/tesseract/bin/tesseract`},
         (err, text) => {
-            if (err) {
-                respond({"error": err});
-                return;
-            }
-            respond({"words": text.split(/[ \n]+/)})
+          if (err) {
+            resolve({"error": err});
+          } else {
+            resolve({"words": text.split(/[ \n]+/)})
+          }
         }
     );
+  });
 }

--- a/separate/runtimes/nodejs/vsock/index.js
+++ b/separate/runtimes/nodejs/vsock/index.js
@@ -2,24 +2,69 @@ const fs = require('fs');
 
 const bindings = require('bindings')('vsock');
 
-exports.connect = bindings.connect;
+class Vsock {
+  constructor(fd) {
+    this.fd = fd;
+    this.readStream = fs.createReadStream("", { fd: fd });
+    this.writeStream = fs.createWriteStream("", { fd: fd });
+    this.readBuffer = Buffer.alloc(0);
+    this.readTarget = 0;
+    this.readEvent = null;
+
+    this.readStream.on('data', (chunk) => {
+      this.readBuffer = Buffer.concat([this.readBuffer, chunk]);
+      this.checkReadReady();
+    });
+  }
+
+  checkReadReady() {
+    if (this.readEvent && this.readBuffer.length >= this.readTarget) {
+      const resBuf = this.readBuffer.slice(0, this.readTarget);
+      this.readBuffer = this.readBuffer.slice(this.readTarget);
+      const evt = this.readEvent;
+      this.readEvent = null;
+      process.nextTick(() => evt(resBuf));
+    }
+  }
+
+  read(i) {
+    return new Promise((resolve, reject) => {
+      this.readEvent = resolve;
+      this.readTarget = i;
+      this.checkReadReady();
+    });
+  }
+
+  write(chunk) {
+    return new Promise((resolve, reject) => {
+      if (this.writeStream.write(chunk)) {
+        process.nextTick(resolve);
+      } else {
+        this.writeStream.once('drain', resolve);
+      }
+    });
+  }
+}
+
+exports.connect = function(port, cid) {
+  const fd = bindings.connect(port, cid);
+  return new Vsock(fd);
+}
 exports.read = bindings.read;
 
-exports.readRequest = function(fd) {
+exports.readRequest = async function(vs) {
   let len = 0;
-  let lenBuf = Buffer.alloc(4);
-  bindings.read(fd, lenBuf);
+  let lenBuf = await vs.read(4);
   len = lenBuf.readUInt32BE();
-  let requestBuf = Buffer.alloc(len);
-  bindings.read(fd, requestBuf);
+  let requestBuf = await vs.read(len);
   return JSON.parse(requestBuf);
 }
 
-exports.writeResponse = function(fd, resp) {
+exports.writeResponse = async function(vs, resp) {
   let respBuf = JSON.stringify(resp);
   let buf = Buffer.alloc(4 + respBuf.length);
   let offset = buf.writeUInt32BE(respBuf.length);
   buf.write(respBuf, offset);
-  fs.writeSync(fd, buf);
+  return await vs.write(buf);
 }
 

--- a/separate/runtimes/nodejs/workload.js
+++ b/separate/runtimes/nodejs/workload.js
@@ -23,14 +23,16 @@ execSync('taskset -c 0 outl 124 0x3f0')
 
 const sock_conn = vsock.connect(2, 1234);
 
-while(true) {
-  const req = vsock.readRequest(sock_conn);
-  const hrstart = process.hrtime()
-  app.handle(req, function(resp) {
+(async function() {
+  while (true) {
+    const req = await vsock.readRequest(sock_conn);
+
+    const hrstart = process.hrtime();
+    const resp = await app.handle(req);
     const hrend = process.hrtime(hrstart)
     resp.runtime_sec = hrend[0];
     resp.runtime_ms = hrend[1] / 1000000;
-    vsock.writeResponse(sock_conn, resp);
-  });
-}
+    await vsock.writeResponse(sock_conn, resp);
+  }
+})();
 


### PR DESCRIPTION
The Node vsock implementation was buggy when there were more than two
requests or if the response was large enough to require multiple writes
to the Vsock. This is because the vsock `write` was not actually
preventing the read (which was blocking) from beginning. So we could get
stuck in situations where the read had begun, and was blocking a write,
and no more requests would arrive.

This PR fixes the problem by acutally making the read/write requests
non-blocking using Node's Readable and Writeable stream interface.

Moreover, the commit changes the interface for Node.js apps to use the
more contemporary Promise-style interface, which allows both the runtime
and app to use `async/await` syntax for much simpler to reason about
implementations.

Fixes #2 