### PR TITLE
Fix nodejs/ocr and python3/ocr

### DIFF
--- a/appfs/nodejs/ocr/Makefile
+++ b/appfs/nodejs/ocr/Makefile
@@ -4,13 +4,13 @@ all: output.ext2
 
 node_modules: package.json workload
 	mkdir -p node_modules
-	echo "apk add nodejs npm; npm install" | docker run -i --rm -v $(mkfile_path):/app -w /app alpine
+	echo "apk add nodejs npm; npm install" | docker run -i --rm -v $(mkfile_path):/app -w /app alpine:3.10
 
 tesseract: compile_tesseract.sh
-	echo "/srv/compile_tesseract.sh" | docker run -i --rm -v $(mkfile_path):/srv -w /tmp alpine
+	echo "/srv/compile_tesseract.sh" | docker run -i --rm -v $(mkfile_path):/srv -w /tmp alpine:3.10
 
 test:
-	echo "apk add nodejs; node -e 'const app = require(\"./workload\"); app.handle({\"img\": \"pitontable.png\"}, console.log);'" | docker run -i --rm -v $(mkfile_path):/srv -w /srv alpine
+	echo "apk add nodejs; node -e 'const app = require(\"./workload\"); app.handle({\"img\": \"pitontable.png\"}, console.log);'" | docker run -i --rm -v $(mkfile_path):/srv -w /srv alpine:3.10
 
 output.ext2: node_modules tesseract
 	rm -rf output.ext2 /tmp/lorem.out/

--- a/appfs/nodejs/ocr/compile_tesseract.sh
+++ b/appfs/nodejs/ocr/compile_tesseract.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-apk add git alpine-sdk cmake make autoconf libtool automake libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev
+apk add git alpine-sdk cmake make autoconf libtool automake libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev libgcc libstdc++
 
 export INSTALL_PREFIX=/srv/tesseract
 
@@ -34,4 +34,5 @@ cp /usr/lib/libpng* /srv/tesseract/lib
 cp /usr/lib/libtiff* /srv/tesseract/lib
 cp /usr/lib/libwebp* /srv/tesseract/lib
 cp /usr/lib/libgif* /srv/tesseract/lib
-
+cp /usr/lib/libgcc* /srv/tesseract/lib
+cp /usr/lib/libstdc++* /srv/tesseract/lib

--- a/appfs/nodejs/ocr/workload
+++ b/appfs/nodejs/ocr/workload
@@ -6,7 +6,10 @@ exports.handle = function(request) {
   return new Promise((resolve, reject) => {
     tesseract.recognize(
         `${__dirname}/${request["img"]}`,
-        {execPath: `${__dirname}/tesseract/bin/tesseract`},
+        {
+          execPath: `${__dirname}/tesseract/bin/tesseract`,
+          tessdataDir: `${__dirname}/tesseract/share/tessdata`
+        },
         (err, text) => {
           if (err) {
             resolve({"error": err});

--- a/appfs/python3/ocr/workload
+++ b/appfs/python3/ocr/workload
@@ -9,13 +9,12 @@ DATA_DIR=os.path.join(TESS_DIR, 'share', 'tessdata')
 
 def handle(request):
     imgfilepath = os.path.join(SCRIPT_DIR, request['img'])
-    jsonfilepath = os.path.join(SCRIPT_DIR, 'result')
     command = 'LD_LIBRARY_PATH={} TESSDATA_PREFIX={} {} {} {}'.format(
         LIB_DIR,
         DATA_DIR,
         BINARY,
         imgfilepath,
-        jsonfilepath,
+        'stdout',
     )
 
     try:

--- a/combined/prelude.sh
+++ b/combined/prelude.sh
@@ -18,3 +18,6 @@ rc-update add serverless-workload default
 ## Add /dev and /proc file systems to openrc's boot
 rc-update add devfs boot
 rc-update add procfs boot
+
+## specify default system library path
+echo '/srv/lib:/lib:/usr/local/lib:/usr/lib' > /etc/ld-musl-$(uname -m).path

--- a/separate/prelude.sh
+++ b/separate/prelude.sh
@@ -18,3 +18,6 @@ rc-update add serverless-workload default
 ## Add /dev and /proc file systems to openrc's boot
 rc-update add devfs boot
 rc-update add procfs boot
+
+## specify default system library path
+echo '/srv/lib:/lib:/usr/local/lib:/usr/lib' > /etc/ld-musl-$(uname -m).path


### PR DESCRIPTION
One main change is to set `/srv/lib` as part of system library path using `/etc/ld-musl-x86_64.path`.

The other changes are making nodejs/ocr placing all required libraries under `./lib` and pointing `tesseract` to the correct `tessdataDir`. For python3/ocr, pointing the output destination to `stdout`.

