### PR TITLE
Debugging java rootfs.sh

### DIFF
--- a/separate/runtimes/java/rootfs.sh
+++ b/separate/runtimes/java/rootfs.sh
@@ -5,11 +5,12 @@ export PATH="$JAVA_HOME/bin:${PATH}"
 
 cp /runtime/lib/*.jar /lib/
 
-javac -h /tmp/ -d /tmp/ /runtime/src/edu/princeton/sns/VSock.java
+javac -h /runtime/src/ -d /tmp/ /runtime/src/edu/princeton/sns/VSock.java
 gcc -fPIC -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/linux" -shared -o /lib/libvsock.so /runtime/src/vsock.c
 jar -cvf /lib/VSock.jar -C /tmp edu
 
 ls /lib/*.jar
+ls /lib/*.so
 javac -cp ".:/lib/json-simple-1.1.1.jar:/lib/VSock.jar" -d /bin/ /runtime/src/RuntimeWorkload.java
 ls /bin/RuntimeWorkload.class
 


### PR DESCRIPTION
There is a bug with the previous commit. Basically, when we compile VSock.java it also generates the header file for vsock.c. Before the header was generated to /tmp/ thus gcc is not able to find it.