### PR TITLE
"No-Runtime" Runtime (C) & Go Runtime

### DIFF
--- a/appfs/go/hello/.gitignore
+++ b/appfs/go/hello/.gitignore
@@ -1,0 +1,1 @@
+workload

--- a/appfs/go/hello/Makefile
+++ b/appfs/go/hello/Makefile
@@ -1,0 +1,16 @@
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+all: output.ext2
+
+workload: workload.go
+	echo "apk add go; go build -buildmode=plugin -o /runtime/workload /runtime/workload.go" | docker run -i --rm -v $(mkfile_path):/runtime alpine
+
+output.ext2: workload
+	rm -rf output.ext2 /tmp/lorem.out/
+	mkdir -p /tmp/lorem.out/
+	touch output.ext2
+	truncate -s 10M output.ext2
+	mkfs.ext2 output.ext2
+	sudo mount output.ext2 /tmp/lorem.out/
+	sudo cp -r workload /tmp/lorem.out/
+	sudo umount /tmp/lorem.out/

--- a/appfs/go/hello/workload.go
+++ b/appfs/go/hello/workload.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+)
+
+func Init() {
+	fmt.Printf("Initializing\n")
+}
+
+type Response struct {
+}
+
+func Handle([]byte) interface{} {
+	return Response{}
+}

--- a/appfs/nort/hello/.gitignore
+++ b/appfs/nort/hello/.gitignore
@@ -1,0 +1,1 @@
+workload

--- a/appfs/nort/hello/Makefile
+++ b/appfs/nort/hello/Makefile
@@ -1,0 +1,16 @@
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+all: output.ext2
+
+workload: workload.c
+	echo "apk add alpine-sdk linux-headers; gcc -O3 -o /runtime/workload /runtime/workload.c" | docker run -i --rm -v $(mkfile_path):/runtime alpine
+
+output.ext2: workload
+	rm -rf output.ext2 /tmp/lorem.out/
+	mkdir -p /tmp/lorem.out/
+	touch output.ext2
+	truncate -s 10M output.ext2
+	mkfs.ext2 output.ext2
+	sudo mount output.ext2 /tmp/lorem.out/
+	sudo cp -r workload /tmp/lorem.out/
+	sudo umount /tmp/lorem.out/

--- a/appfs/nort/hello/Makefile
+++ b/appfs/nort/hello/Makefile
@@ -3,7 +3,7 @@ mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 all: output.ext2
 
 workload: workload.c
-	echo "apk add alpine-sdk linux-headers; gcc -O3 -o /runtime/workload /runtime/workload.c" | docker run -i --rm -v $(mkfile_path):/runtime alpine
+	echo "apk add alpine-sdk linux-headers; gcc -O3 -o /runtime/workload -fPIC -shared /runtime/workload.c" | docker run -i --rm -v $(mkfile_path):/runtime alpine
 
 output.ext2: workload
 	rm -rf output.ext2 /tmp/lorem.out/

--- a/appfs/nort/hello/workload.c
+++ b/appfs/nort/hello/workload.c
@@ -1,0 +1,63 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
+
+static int vsock_connect(int cid, int port)
+{
+	int fd;
+	struct sockaddr_vm sa = {
+    .svm_family =  AF_VSOCK,
+  };
+	sa.svm_cid = cid;
+	sa.svm_port = port;
+
+	fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+	if (fd < 0) {
+		perror("socket");
+		return -1;
+	}
+
+	if (connect(fd, (struct sockaddr*)&sa, sizeof(sa)) != 0) {
+		perror("connect");
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+char *payload = "{\"body\": \"hello, world!\"}";
+
+int main() {
+  char throwaway[1];
+  write(4, throwaway, 1);
+  close(4); // Ready for a snapshot!
+
+  read(3, throwaway, 1); // Wait for snapshot to be done
+  close(3);
+
+  int vsock = vsock_connect(2, 1234);
+  if (vsock < 0) {
+    exit(-1);
+  }
+
+  for (;;) {
+    uint32_t buffer_length = 0;
+    read(vsock, (char*)&buffer_length, 4);
+    buffer_length = ntohl(buffer_length);
+    char *buffer = (char*)malloc(buffer_length);
+    read(vsock, buffer, buffer_length);
+
+    free(buffer);
+
+    uint32_t payload_len = strlen(payload);
+    uint32_t payload_len_buf = htonl(payload_len);
+    write(vsock, (char*)&payload_len_buf, 4);
+    write(vsock, payload, payload_len);
+  }
+}

--- a/appfs/nort/hello/workload.c
+++ b/appfs/nort/hello/workload.c
@@ -1,63 +1,14 @@
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
-#include <arpa/inet.h>
-#include <sys/socket.h>
-#include <linux/vm_sockets.h>
 
-static int vsock_connect(int cid, int port)
-{
-	int fd;
-	struct sockaddr_vm sa = {
-    .svm_family =  AF_VSOCK,
-  };
-	sa.svm_cid = cid;
-	sa.svm_port = port;
-
-	fd = socket(AF_VSOCK, SOCK_STREAM, 0);
-	if (fd < 0) {
-		perror("socket");
-		return -1;
-	}
-
-	if (connect(fd, (struct sockaddr*)&sa, sizeof(sa)) != 0) {
-		perror("connect");
-		close(fd);
-		return -1;
-	}
-
-	return fd;
+void init() {
+  return;
 }
 
-char *payload = "{\"body\": \"hello, world!\"}";
+typedef void responder(char*, uint32_t);
 
-int main() {
-  char throwaway[1];
-  write(4, throwaway, 1);
-  close(4); // Ready for a snapshot!
-
-  read(3, throwaway, 1); // Wait for snapshot to be done
-  close(3);
-
-  int vsock = vsock_connect(2, 1234);
-  if (vsock < 0) {
-    exit(-1);
-  }
-
-  for (;;) {
-    uint32_t buffer_length = 0;
-    read(vsock, (char*)&buffer_length, 4);
-    buffer_length = ntohl(buffer_length);
-    char *buffer = (char*)malloc(buffer_length);
-    read(vsock, buffer, buffer_length);
-
-    free(buffer);
-
-    uint32_t payload_len = strlen(payload);
-    uint32_t payload_len_buf = htonl(payload_len);
-    write(vsock, (char*)&payload_len_buf, 4);
-    write(vsock, payload, payload_len);
-  }
+void handle(char *request, uint32_t len, responder respond) {
+  static char *payload = "{\"body\": \"hello, world!\"}";
+  len = strlen(payload);
+  respond(payload, len);
 }

--- a/separate/runtimes/go/.gitignore
+++ b/separate/runtimes/go/.gitignore
@@ -1,0 +1,1 @@
+workload

--- a/separate/runtimes/go/Makefile
+++ b/separate/runtimes/go/Makefile
@@ -1,0 +1,6 @@
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+all: workload
+
+workload: workload.go
+	echo "apk add git go; go get -u golang.org/x/sys/unix; go build -o /runtime/workload /runtime/workload.go" | docker run -i --rm -v $(mkfile_path):/runtime alpine

--- a/separate/runtimes/go/rootfs.sh
+++ b/separate/runtimes/go/rootfs.sh
@@ -1,0 +1,12 @@
+cp /runtime/workload /bin/runtime-workload-elf
+cat > /bin/runtime-workload <<EOF
+#!/bin/sh
+/usr/bin/setup-eth0.sh
+/usr/bin/ioctl
+/usr/bin/factorial $((1 << 28))
+/bin/runtime-workload-elf /srv/workload
+EOF
+chmod +x /bin/runtime-workload
+chmod +x /bin/runtime-workload-elf
+
+cp /common/factorial /usr/bin/factorial

--- a/separate/runtimes/go/workload.go
+++ b/separate/runtimes/go/workload.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"plugin"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	err := unix.Iopl(3)
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 1; i < runtime.NumCPU(); i++ {
+		exec.Command("taskset", "-c", string(i), "outl", "124", "0x3f0").Run()
+	}
+	exec.Command("taskset", "-c", "0", "outl", "124", "0x3f0").Run()
+
+	if unix.Mount("/dev/vdb", "/srv", "ext2", unix.MS_RDONLY, "") != nil {
+		panic("Failed to mount")
+	}
+
+	p, err := plugin.Open(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	initptr, err := p.Lookup("Init")
+	if err != nil {
+		panic(err)
+	}
+	handleptr, err := p.Lookup("Handle")
+	if err != nil {
+		panic(err)
+	}
+
+	init := initptr.(func())
+	handle := handleptr.(func([]byte) interface{})
+
+	init()
+
+	for i := 1; i < runtime.NumCPU(); i++ {
+		exec.Command("taskset", "-c", string(i), "outl", "124", "0x3f0").Run()
+	}
+	exec.Command("taskset", "-c", "0", "outl", "124", "0x3f0").Run()
+
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		panic(err)
+	}
+	sa := unix.SockaddrVM{
+		CID:  2,
+		Port: 1234,
+	}
+	err = unix.Connect(fd, &sa)
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		lenbuf := make([]byte, 4)
+		_, err = unix.Read(fd, lenbuf)
+		if err != nil {
+			panic(err)
+		}
+		reqlen := binary.BigEndian.Uint32(lenbuf)
+		reqbuf := make([]byte, reqlen)
+		_, err = unix.Read(fd, reqbuf)
+		if err != nil {
+			panic(err)
+		}
+
+		response := handle(reqbuf)
+
+		responseBuf, err := json.Marshal(response)
+
+		binary.BigEndian.PutUint32(lenbuf, uint32(len(responseBuf)))
+		_, err = unix.Write(fd, lenbuf)
+		if err != nil {
+			panic(err)
+		}
+		unix.Write(fd, responseBuf)
+	}
+}

--- a/separate/runtimes/nort/.gitignore
+++ b/separate/runtimes/nort/.gitignore
@@ -1,0 +1,1 @@
+workload

--- a/separate/runtimes/nort/Makefile
+++ b/separate/runtimes/nort/Makefile
@@ -1,0 +1,6 @@
+mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+all: workload
+
+workload: workload.c
+	echo "apk add alpine-sdk linux-headers; gcc -O3 -o /runtime/workload /runtime/workload.c" | docker run -i --rm -v $(mkfile_path):/runtime alpine

--- a/separate/runtimes/nort/rootfs.sh
+++ b/separate/runtimes/nort/rootfs.sh
@@ -1,0 +1,12 @@
+cp /runtime/workload /bin/runtime-workload-elf
+cat > /bin/runtime-workload <<EOF
+#!/bin/sh
+/usr/bin/setup-eth0.sh
+/usr/bin/ioctl
+/usr/bin/factorial $((1 << 28))
+/bin/runtime-workload-elf /srv/workload
+EOF
+chmod +x /bin/runtime-workload
+chmod +x /bin/runtime-workload-elf
+
+cp /common/factorial /usr/bin/factorial

--- a/separate/runtimes/nort/workload.c
+++ b/separate/runtimes/nort/workload.c
@@ -5,25 +5,73 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <dlfcn.h>
 #include <fcntl.h>
 #include <sched.h>
 #include <unistd.h>
 
+#include <arpa/inet.h>
+
 #include <sys/io.h>
 #include <sys/ioctl.h>
 #include <sys/mount.h>
-#include <sys/wait.h>
 
 #include <linux/random.h>
+#include <linux/vm_sockets.h>
 
-#ifndef FAKE_SNAP
+typedef void initfunc(void);
+typedef void responder(char*, uint32_t);
+typedef void handlefunc(char*,uint32_t,responder);
+
+#ifdef TEST
+static int vsock_connect(int cid, int port)
+{
+  return 0;
+}
+#else
+static int vsock_connect(int cid, int port)
+{
+	int fd;
+	struct sockaddr_vm sa = {
+    .svm_family =  AF_VSOCK,
+  };
+	sa.svm_cid = cid;
+	sa.svm_port = port;
+
+	fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+	if (fd < 0) {
+		perror("socket");
+		return -1;
+	}
+
+	if (connect(fd, (struct sockaddr*)&sa, sizeof(sa)) != 0) {
+		perror("connect");
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+#endif
+
+#ifdef TEST
+// Fake snapshot function for local testing
+void snapshot() {
+  setbuf(stdout, NULL);
+  printf("Snapshotting...");
+  for (int i = 0; i < 100000000; i++) {
+    asm("nop");
+  }
+  printf("Done\n");
+}
+#else
 void snapshot() {
   // Make sure we are allowed to perform `outl`
   if (iopl(3)) {perror("iopl"); exit(1);}
 
+  cpu_set_t cset;
   // Let VMM know each of the CPUS is ready for a snapshot
   for (int cpu = 1; ; cpu++) {
-    cpu_set_t cset;
     CPU_ZERO(&cset);
     CPU_SET(cpu, &cset);
     if (sched_setaffinity(0, sizeof(cpu_set_t), &cset) < 0) {
@@ -35,75 +83,53 @@ void snapshot() {
   }
 
   // Finally, signal the VMM to start snapshotting from the main CPU
-  cpu_set_t cset;
   CPU_ZERO(&cset);
   CPU_SET(0, &cset);
   sched_setaffinity(0, sizeof(cset), &cset);
   outl(124, 0x3f0);
 }
-#else
-// Fake snapshot function for local testing
-void snapshot() {
-  setbuf(stdout, NULL);
-  printf("Snapshotting...");
-  for (int i = 0; i < 100000000; i++) {
-    asm("nop");
-  }
-  printf("Done\n");
-}
 #endif
+
+int vsock;
+
+static void respond(char *response, uint32_t response_len) {
+  uint32_t response_len_buf = htonl(response_len);
+  write(vsock, (char*)&response_len_buf, 4);
+  write(vsock, response, response_len);
+}
 
 int main(int argc, char* argv[]) {
   snapshot();
 
+#ifndef TEST
   // Mount the function filesystem
   if (mount("/dev/vdb", "/srv", "ext2", MS_RDONLY, NULL) < 0) {
     perror("mount");
   }
+#endif
 
-  // We'll signal readiness between parent & child using a pipe.
-  int p2c_pipefds[2];
-  pipe(p2c_pipefds);
-  int c2p_pipefds[2];
-  pipe(c2p_pipefds);
+  void *libhandle = dlopen(argv[1], RTLD_NOW);
+  initfunc *init = dlsym(libhandle, "init");
+  handlefunc *handle = dlsym(libhandle, "handle");
 
-  int pid = fork();
-  if (pid == 0) {
-    // Child process
+  init();
 
-    // Close parent's side of pipes
-    close(p2c_pipefds[1]);
-    close(c2p_pipefds[0]);
+  snapshot();
 
-    dup2(p2c_pipefds[0], 3); // read from parent
-    dup2(c2p_pipefds[1], 4); // write to parent
-    // Run, child!
-    char *argv2[2] = { argv[1], NULL };
-    exit(execv(argv[1], argv2));
-  } else {
-    // Parent process
+  vsock = vsock_connect(2, 1234);
+  if (vsock < 0) {
+    exit(-1);
+  }
+  printf("connected\n");
 
-    // Close child's side of pipes
-    close(p2c_pipefds[0]);
-    close(c2p_pipefds[1]);
+  for (;;) {
+    uint32_t buffer_length = 0;
+    read(vsock, (char*)&buffer_length, 4);
+    buffer_length = ntohl(buffer_length);
+    char *buffer = (char*)malloc(buffer_length);
+    read(vsock, buffer, buffer_length);
 
-    // Wait for child pipe to close;
-    char throwaway[1];
-    read(c2p_pipefds[0], throwaway, 1);
-    close(c2p_pipefds[0]);
-
-    snapshot();
-
-    // Signal child we're done snapshotting and it can open vsock
-    write(p2c_pipefds[1], throwaway, 1);
-    close(p2c_pipefds[1]);
-
-    // Wait for the child to exit
-    int status;
-    do {
-      waitpid(pid, &status, 0);
-    } while (!WIFEXITED(status));
-    exit(WEXITSTATUS(status));
+    handle(buffer, buffer_length, &respond);
   }
 }
 

--- a/separate/runtimes/nort/workload.c
+++ b/separate/runtimes/nort/workload.c
@@ -1,0 +1,109 @@
+#define _GNU_SOURCE
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <fcntl.h>
+#include <sched.h>
+#include <unistd.h>
+
+#include <sys/io.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <sys/wait.h>
+
+#include <linux/random.h>
+
+#ifndef FAKE_SNAP
+void snapshot() {
+  // Make sure we are allowed to perform `outl`
+  if (iopl(3)) {perror("iopl"); exit(1);}
+
+  // Let VMM know each of the CPUS is ready for a snapshot
+  for (int cpu = 1; ; cpu++) {
+    cpu_set_t cset;
+    CPU_ZERO(&cset);
+    CPU_SET(cpu, &cset);
+    if (sched_setaffinity(0, sizeof(cpu_set_t), &cset) < 0) {
+      // If we got an error assume it's because the CPU doesn't exist, so we're done
+      break;
+    } else {
+      outl(124, 0x3f0);
+    }
+  }
+
+  // Finally, signal the VMM to start snapshotting from the main CPU
+  cpu_set_t cset;
+  CPU_ZERO(&cset);
+  CPU_SET(0, &cset);
+  sched_setaffinity(0, sizeof(cset), &cset);
+  outl(124, 0x3f0);
+}
+#else
+// Fake snapshot function for local testing
+void snapshot() {
+  setbuf(stdout, NULL);
+  printf("Snapshotting...");
+  for (int i = 0; i < 100000000; i++) {
+    asm("nop");
+  }
+  printf("Done\n");
+}
+#endif
+
+int main(int argc, char* argv[]) {
+  snapshot();
+
+  // Mount the function filesystem
+  if (mount("/dev/vdb", "/srv", "ext2", MS_RDONLY, NULL) < 0) {
+    perror("mount");
+  }
+
+  // We'll signal readiness between parent & child using a pipe.
+  int p2c_pipefds[2];
+  pipe(p2c_pipefds);
+  int c2p_pipefds[2];
+  pipe(c2p_pipefds);
+
+  int pid = fork();
+  if (pid == 0) {
+    // Child process
+
+    // Close parent's side of pipes
+    close(p2c_pipefds[1]);
+    close(c2p_pipefds[0]);
+
+    dup2(p2c_pipefds[0], 3); // read from parent
+    dup2(c2p_pipefds[1], 4); // write to parent
+    // Run, child!
+    char *argv2[2] = { argv[1], NULL };
+    exit(execv(argv[1], argv2));
+  } else {
+    // Parent process
+
+    // Close child's side of pipes
+    close(p2c_pipefds[0]);
+    close(c2p_pipefds[1]);
+
+    // Wait for child pipe to close;
+    char throwaway[1];
+    read(c2p_pipefds[0], throwaway, 1);
+    close(c2p_pipefds[0]);
+
+    snapshot();
+
+    // Signal child we're done snapshotting and it can open vsock
+    write(p2c_pipefds[1], throwaway, 1);
+    close(p2c_pipefds[1]);
+
+    // Wait for the child to exit
+    int status;
+    do {
+      waitpid(pid, &status, 0);
+    } while (!WIFEXITED(status));
+    exit(WEXITSTATUS(status));
+  }
+}
+


### PR DESCRIPTION
A runtime and hello app example for non-runtime languages (C & Rust,
e.g.).

The "runtime" component is responsible for setting up the environment,
connecting and reading/writing from the vsock, but no serializing/deserializing requests and responses.

~There is a simple pipe-based signaling protocol for the app to indicate, first,
that the app is ready for the runtime to take a diff-snapshot and then,
second, for the runtime to indicate to the app that it is done
diff-snapshotting and the app should begin it's communication over
vsock.~

The application must be a dynamically loadable shared library, e.g., compiled with `gcc -shared -fPIC`, which the runtime loads using `dlopen`. It must contain two functions:

```c
void init(void);

typedef void responder(char*, uint32_t);
int handle(char *request, int req_len, responder);
```

`init` is called once by the runtime to perform any initialization tasks the app may want. `handle is called within the request/response loop. It is passed the request as a base pointer and length pointing to a JSON string. The outputs a response by calling the passed in `responder` function.

The runtime is in `separate/runtimes/nort` and the example app is in `appfs/nort/hello`.

On my local machine, boot time with either runtime-only or full-snapfaas snapshots are ~6ms with execution time of the hello app around 20-60us. With no snapshotting, boot time is dominate by Linux boot time at around 500ms, but the runtime includes the factorial hack (which adds an addition significant latency).
