### PR TITLE
System call support for GH put/delete, "invoke", and labeled filesystem

### DIFF
--- a/rootfs/common/prelude.sh
+++ b/rootfs/common/prelude.sh
@@ -1,4 +1,4 @@
-apk add openrc util-linux
+apk add openrc util-linux build-base
 
 cp /common/outl /usr/bin/outl
 cp /common/setup-eth0.sh /usr/bin/setup-eth0.sh

--- a/rootfs/regular/mk_appimage.sh
+++ b/rootfs/regular/mk_appimage.sh
@@ -62,10 +62,10 @@ if [ ! -f "$RUNTIME"/rootfs.sh ]; then
   exit 1
 fi
 
-if [ ! -f "$APP"/Makefile ]; then
-  echo "App \`$2\` not found."
-  exit 1
-fi
+#if [ ! -f "$APP"/Makefile ]; then
+#  echo "App \`$2\` not found."
+#  exit 1
+#fi
 
 RUNTIME=$(realpath $RUNTIME)
 MYDIR=$(dirname $(realpath $0))
@@ -75,28 +75,31 @@ fi
 
 make -C $RUNTIME
 make -C $MYDIR/../common
-make -C $APP
+#make -C $APP
 
 ## Create a temporary directory to mount the filesystem
 MTMPDIR=`mktemp -d`
-APPTMPDIR=`mktemp -d`
+#APPTMPDIR=`mktemp -d`
 
 ## Delete the output file if it exists, and create a new one formatted as
 ## an EXT4 filesystem.
 rm -f $OUTPUT
-dd if=/dev/zero of=$OUTPUT bs=1M count=1000
+truncate -s 500M $OUTPUT
 mkfs.ext4 $OUTPUT
 
 ## Mount the output file in the temporary directory
 sudo mount $OUTPUT $MTMPDIR
-sudo mount $APP/output.ext2 $APPTMPDIR
+#sudo mount $APP/output.ext2 $APPTMPDIR
 
 ## Execute the prelude, runtime script and postscript inside an Alpine docker container
 ## with the target root file system shared at `/my-rootfs` inside the container.
-cat $MYDIR/../common/prelude.sh $DEBUG $RUNTIME/rootfs.sh $MYDIR/../common/postscript.sh | docker run -i --rm -v $MTMPDIR:/my-rootfs -v $MYDIR/../common:/common -v $RUNTIME:/runtime -v $APPTMPDIR:/my-app alpine:3.10
+cat $MYDIR/../common/prelude.sh $DEBUG $RUNTIME/rootfs.sh $MYDIR/../common/postscript.sh | docker run -i --rm -v $MTMPDIR:/my-rootfs -v $MYDIR/../common:/common -v $RUNTIME:/runtime alpine:3.10
 
 ## Cleanup
+#sudo umount $APPTMPDIR
+#rm -Rf $APPTMPDIR
+
 sudo umount $MTMPDIR
 rm -Rf $MTMPDIR
-sudo umount $APPTMPDIR
-rm -Rf $APPTMPDIR
+#tar czf $RUNTIME.tar.gz $MTMPDIR
+

--- a/rootfs/regular/runtimes/python3/rootfs.sh
+++ b/rootfs/regular/runtimes/python3/rootfs.sh
@@ -1,7 +1,7 @@
 apk add bash python3 python3-dev
 
 # Copy application over
-cp -r /my-app/* /srv
+#cp -r /my-app/* /srv
 
 cp -r /runtime/google /usr/lib/python3.7/google
 cp /runtime/workload.py /bin/runtime-workload.py

--- a/rootfs/regular/runtimes/python3/syscalls_pb2.py
+++ b/rootfs/regular/runtimes/python3/syscalls_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0esyscalls.proto\x12\x11snapfaas.syscalls\"+\n\x06Invoke\x12\x10\n\x08\x66unction\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\"!\n\x0eInvokeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x1c\n\x06\x43lause\x12\x12\n\nprincipals\x18\x01 \x03(\t\"7\n\tComponent\x12*\n\x07\x63lauses\x18\x01 \x03(\x0b\x32\x19.snapfaas.syscalls.Clause\"\x8d\x01\n\x07\x44\x63Label\x12\x32\n\x07secrecy\x18\x01 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x00\x88\x01\x01\x12\x34\n\tintegrity\x18\x02 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x01\x88\x01\x01\x42\n\n\x08_secrecyB\x0c\n\n_integrity\"\x1a\n\x07Request\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x1b\n\x08Response\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x16\n\x07ReadKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\"/\n\x0fReadKeyResponse\x12\x12\n\x05value\x18\x01 \x01(\x0cH\x00\x88\x01\x01\x42\x08\n\x06_value\"&\n\x08WriteKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\x12\r\n\x05value\x18\x02 \x01(\x0c\"#\n\x10WriteKeyResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"b\n\nGithubRest\x12)\n\x04verb\x18\x01 \x01(\x0e\x32\x1b.snapfaas.syscalls.HttpVerb\x12\r\n\x05route\x18\x02 \x01(\t\x12\x11\n\x04\x62ody\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_body\"2\n\x12GithubRestResponse\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x0e\n\x06status\x18\x02 \x01(\r\"\x11\n\x0fGetCurrentLabel\"\xfc\x02\n\x07Syscall\x12/\n\x08response\x18\x01 \x01(\x0b\x32\x1b.snapfaas.syscalls.ResponseH\x00\x12-\n\x07readKey\x18\x02 \x01(\x0b\x32\x1a.snapfaas.syscalls.ReadKeyH\x00\x12/\n\x08writeKey\x18\x03 \x01(\x0b\x32\x1b.snapfaas.syscalls.WriteKeyH\x00\x12=\n\x0fgetCurrentLabel\x18\x04 \x01(\x0b\x32\".snapfaas.syscalls.GetCurrentLabelH\x00\x12\x34\n\x0etaintWithLabel\x18\x05 \x01(\x0b\x32\x1a.snapfaas.syscalls.DcLabelH\x00\x12\x33\n\ngithubRest\x18\x06 \x01(\x0b\x32\x1d.snapfaas.syscalls.GithubRestH\x00\x12+\n\x06invoke\x18\x07 \x01(\x0b\x32\x19.snapfaas.syscalls.InvokeH\x00\x42\t\n\x07syscall*2\n\x08HttpVerb\x12\x07\n\x03GET\x10\x00\x12\x08\n\x04POST\x10\x01\x12\x07\n\x03PUT\x10\x02\x12\n\n\x06\x44\x45LETE\x10\x04\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0esyscalls.proto\x12\x11snapfaas.syscalls\"+\n\x06Invoke\x12\x10\n\x08\x66unction\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\"!\n\x0eInvokeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x1c\n\x06\x43lause\x12\x12\n\nprincipals\x18\x01 \x03(\t\"7\n\tComponent\x12*\n\x07\x63lauses\x18\x01 \x03(\x0b\x32\x19.snapfaas.syscalls.Clause\"\x8d\x01\n\x07\x44\x63Label\x12\x32\n\x07secrecy\x18\x01 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x00\x88\x01\x01\x12\x34\n\tintegrity\x18\x02 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x01\x88\x01\x01\x42\n\n\x08_secrecyB\x0c\n\n_integrity\"\x1a\n\x07Request\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x1b\n\x08Response\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x16\n\x07ReadKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\"/\n\x0fReadKeyResponse\x12\x12\n\x05value\x18\x01 \x01(\x0cH\x00\x88\x01\x01\x42\x08\n\x06_value\"&\n\x08WriteKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\x12\r\n\x05value\x18\x02 \x01(\x0c\"#\n\x10WriteKeyResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"b\n\nGithubRest\x12)\n\x04verb\x18\x01 \x01(\x0e\x32\x1b.snapfaas.syscalls.HttpVerb\x12\r\n\x05route\x18\x02 \x01(\t\x12\x11\n\x04\x62ody\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_body\"2\n\x12GithubRestResponse\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x0e\n\x06status\x18\x02 \x01(\r\"\x11\n\x0fGetCurrentLabel\"\x16\n\x06\x46SRead\x12\x0c\n\x04path\x18\x01 \x01(\t\"%\n\x07\x46SWrite\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\"W\n\x0b\x46SCreateDir\x12\x0f\n\x07\x62\x61seDir\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12)\n\x05label\x18\x03 \x01(\x0b\x32\x1a.snapfaas.syscalls.DcLabel\"X\n\x0c\x46SCreateFile\x12\x0f\n\x07\x62\x61seDir\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12)\n\x05label\x18\x03 \x01(\x0b\x32\x1a.snapfaas.syscalls.DcLabel\"\xc8\x04\n\x07Syscall\x12/\n\x08response\x18\x01 \x01(\x0b\x32\x1b.snapfaas.syscalls.ResponseH\x00\x12-\n\x07readKey\x18\x02 \x01(\x0b\x32\x1a.snapfaas.syscalls.ReadKeyH\x00\x12/\n\x08writeKey\x18\x03 \x01(\x0b\x32\x1b.snapfaas.syscalls.WriteKeyH\x00\x12=\n\x0fgetCurrentLabel\x18\x04 \x01(\x0b\x32\".snapfaas.syscalls.GetCurrentLabelH\x00\x12\x34\n\x0etaintWithLabel\x18\x05 \x01(\x0b\x32\x1a.snapfaas.syscalls.DcLabelH\x00\x12\x33\n\ngithubRest\x18\x06 \x01(\x0b\x32\x1d.snapfaas.syscalls.GithubRestH\x00\x12+\n\x06invoke\x18\x07 \x01(\x0b\x32\x19.snapfaas.syscalls.InvokeH\x00\x12+\n\x06\x66sRead\x18\x08 \x01(\x0b\x32\x19.snapfaas.syscalls.FSReadH\x00\x12-\n\x07\x66sWrite\x18\t \x01(\x0b\x32\x1a.snapfaas.syscalls.FSWriteH\x00\x12\x35\n\x0b\x66sCreateDir\x18\n \x01(\x0b\x32\x1e.snapfaas.syscalls.FSCreateDirH\x00\x12\x37\n\x0c\x66sCreateFile\x18\x0b \x01(\x0b\x32\x1f.snapfaas.syscalls.FSCreateFileH\x00\x42\t\n\x07syscall*2\n\x08HttpVerb\x12\x07\n\x03GET\x10\x00\x12\x08\n\x04POST\x10\x01\x12\x07\n\x03PUT\x10\x02\x12\n\n\x06\x44\x45LETE\x10\x04\x62\x06proto3')
 
 _HTTPVERB = DESCRIPTOR.enum_types_by_name['HttpVerb']
 HttpVerb = enum_type_wrapper.EnumTypeWrapper(_HTTPVERB)
@@ -39,6 +39,10 @@ _WRITEKEYRESPONSE = DESCRIPTOR.message_types_by_name['WriteKeyResponse']
 _GITHUBREST = DESCRIPTOR.message_types_by_name['GithubRest']
 _GITHUBRESTRESPONSE = DESCRIPTOR.message_types_by_name['GithubRestResponse']
 _GETCURRENTLABEL = DESCRIPTOR.message_types_by_name['GetCurrentLabel']
+_FSREAD = DESCRIPTOR.message_types_by_name['FSRead']
+_FSWRITE = DESCRIPTOR.message_types_by_name['FSWrite']
+_FSCREATEDIR = DESCRIPTOR.message_types_by_name['FSCreateDir']
+_FSCREATEFILE = DESCRIPTOR.message_types_by_name['FSCreateFile']
 _SYSCALL = DESCRIPTOR.message_types_by_name['Syscall']
 Invoke = _reflection.GeneratedProtocolMessageType('Invoke', (_message.Message,), {
   'DESCRIPTOR' : _INVOKE,
@@ -138,6 +142,34 @@ GetCurrentLabel = _reflection.GeneratedProtocolMessageType('GetCurrentLabel', (_
   })
 _sym_db.RegisterMessage(GetCurrentLabel)
 
+FSRead = _reflection.GeneratedProtocolMessageType('FSRead', (_message.Message,), {
+  'DESCRIPTOR' : _FSREAD,
+  '__module__' : 'syscalls_pb2'
+  # @@protoc_insertion_point(class_scope:snapfaas.syscalls.FSRead)
+  })
+_sym_db.RegisterMessage(FSRead)
+
+FSWrite = _reflection.GeneratedProtocolMessageType('FSWrite', (_message.Message,), {
+  'DESCRIPTOR' : _FSWRITE,
+  '__module__' : 'syscalls_pb2'
+  # @@protoc_insertion_point(class_scope:snapfaas.syscalls.FSWrite)
+  })
+_sym_db.RegisterMessage(FSWrite)
+
+FSCreateDir = _reflection.GeneratedProtocolMessageType('FSCreateDir', (_message.Message,), {
+  'DESCRIPTOR' : _FSCREATEDIR,
+  '__module__' : 'syscalls_pb2'
+  # @@protoc_insertion_point(class_scope:snapfaas.syscalls.FSCreateDir)
+  })
+_sym_db.RegisterMessage(FSCreateDir)
+
+FSCreateFile = _reflection.GeneratedProtocolMessageType('FSCreateFile', (_message.Message,), {
+  'DESCRIPTOR' : _FSCREATEFILE,
+  '__module__' : 'syscalls_pb2'
+  # @@protoc_insertion_point(class_scope:snapfaas.syscalls.FSCreateFile)
+  })
+_sym_db.RegisterMessage(FSCreateFile)
+
 Syscall = _reflection.GeneratedProtocolMessageType('Syscall', (_message.Message,), {
   'DESCRIPTOR' : _SYSCALL,
   '__module__' : 'syscalls_pb2'
@@ -148,8 +180,8 @@ _sym_db.RegisterMessage(Syscall)
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _HTTPVERB._serialized_start=1109
-  _HTTPVERB._serialized_end=1159
+  _HTTPVERB._serialized_start=1555
+  _HTTPVERB._serialized_end=1605
   _INVOKE._serialized_start=37
   _INVOKE._serialized_end=80
   _INVOKERESPONSE._serialized_start=82
@@ -178,6 +210,14 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _GITHUBRESTRESPONSE._serialized_end=705
   _GETCURRENTLABEL._serialized_start=707
   _GETCURRENTLABEL._serialized_end=724
-  _SYSCALL._serialized_start=727
-  _SYSCALL._serialized_end=1107
+  _FSREAD._serialized_start=726
+  _FSREAD._serialized_end=748
+  _FSWRITE._serialized_start=750
+  _FSWRITE._serialized_end=787
+  _FSCREATEDIR._serialized_start=789
+  _FSCREATEDIR._serialized_end=876
+  _FSCREATEFILE._serialized_start=878
+  _FSCREATEFILE._serialized_end=966
+  _SYSCALL._serialized_start=969
+  _SYSCALL._serialized_end=1553
 # @@protoc_insertion_point(module_scope)

--- a/rootfs/regular/runtimes/python3/syscalls_pb2.py
+++ b/rootfs/regular/runtimes/python3/syscalls_pb2.py
@@ -15,14 +15,18 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0esyscalls.proto\x12\x11snapfaas.syscalls\"\x1c\n\x06\x43lause\x12\x12\n\nprincipals\x18\x01 \x03(\t\"7\n\tComponent\x12*\n\x07\x63lauses\x18\x01 \x03(\x0b\x32\x19.snapfaas.syscalls.Clause\"\x8d\x01\n\x07\x44\x63Label\x12\x32\n\x07secrecy\x18\x01 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x00\x88\x01\x01\x12\x34\n\tintegrity\x18\x02 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x01\x88\x01\x01\x42\n\n\x08_secrecyB\x0c\n\n_integrity\"\x1a\n\x07Request\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x1b\n\x08Response\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x16\n\x07ReadKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\"/\n\x0fReadKeyResponse\x12\x12\n\x05value\x18\x01 \x01(\x0cH\x00\x88\x01\x01\x42\x08\n\x06_value\"&\n\x08WriteKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\x12\r\n\x05value\x18\x02 \x01(\x0c\"#\n\x10WriteKeyResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"b\n\nGithubRest\x12)\n\x04verb\x18\x01 \x01(\x0e\x32\x1b.snapfaas.syscalls.HttpVerb\x12\r\n\x05route\x18\x02 \x01(\t\x12\x11\n\x04\x62ody\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_body\"\"\n\x12GithubRestResponse\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\"\x11\n\x0fGetCurrentLabel\"\xcf\x02\n\x07Syscall\x12/\n\x08response\x18\x01 \x01(\x0b\x32\x1b.snapfaas.syscalls.ResponseH\x00\x12-\n\x07readKey\x18\x02 \x01(\x0b\x32\x1a.snapfaas.syscalls.ReadKeyH\x00\x12/\n\x08writeKey\x18\x03 \x01(\x0b\x32\x1b.snapfaas.syscalls.WriteKeyH\x00\x12=\n\x0fgetCurrentLabel\x18\x04 \x01(\x0b\x32\".snapfaas.syscalls.GetCurrentLabelH\x00\x12\x34\n\x0etaintWithLabel\x18\x05 \x01(\x0b\x32\x1a.snapfaas.syscalls.DcLabelH\x00\x12\x33\n\ngithubRest\x18\x06 \x01(\x0b\x32\x1d.snapfaas.syscalls.GithubRestH\x00\x42\t\n\x07syscall*\x1d\n\x08HttpVerb\x12\x07\n\x03GET\x10\x00\x12\x08\n\x04POST\x10\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0esyscalls.proto\x12\x11snapfaas.syscalls\"+\n\x06Invoke\x12\x10\n\x08\x66unction\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\"!\n\x0eInvokeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x1c\n\x06\x43lause\x12\x12\n\nprincipals\x18\x01 \x03(\t\"7\n\tComponent\x12*\n\x07\x63lauses\x18\x01 \x03(\x0b\x32\x19.snapfaas.syscalls.Clause\"\x8d\x01\n\x07\x44\x63Label\x12\x32\n\x07secrecy\x18\x01 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x00\x88\x01\x01\x12\x34\n\tintegrity\x18\x02 \x01(\x0b\x32\x1c.snapfaas.syscalls.ComponentH\x01\x88\x01\x01\x42\n\n\x08_secrecyB\x0c\n\n_integrity\"\x1a\n\x07Request\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x1b\n\x08Response\x12\x0f\n\x07payload\x18\x01 \x01(\t\"\x16\n\x07ReadKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\"/\n\x0fReadKeyResponse\x12\x12\n\x05value\x18\x01 \x01(\x0cH\x00\x88\x01\x01\x42\x08\n\x06_value\"&\n\x08WriteKey\x12\x0b\n\x03key\x18\x01 \x01(\x0c\x12\r\n\x05value\x18\x02 \x01(\x0c\"#\n\x10WriteKeyResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"b\n\nGithubRest\x12)\n\x04verb\x18\x01 \x01(\x0e\x32\x1b.snapfaas.syscalls.HttpVerb\x12\r\n\x05route\x18\x02 \x01(\t\x12\x11\n\x04\x62ody\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_body\"2\n\x12GithubRestResponse\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x0e\n\x06status\x18\x02 \x01(\r\"\x11\n\x0fGetCurrentLabel\"\xfc\x02\n\x07Syscall\x12/\n\x08response\x18\x01 \x01(\x0b\x32\x1b.snapfaas.syscalls.ResponseH\x00\x12-\n\x07readKey\x18\x02 \x01(\x0b\x32\x1a.snapfaas.syscalls.ReadKeyH\x00\x12/\n\x08writeKey\x18\x03 \x01(\x0b\x32\x1b.snapfaas.syscalls.WriteKeyH\x00\x12=\n\x0fgetCurrentLabel\x18\x04 \x01(\x0b\x32\".snapfaas.syscalls.GetCurrentLabelH\x00\x12\x34\n\x0etaintWithLabel\x18\x05 \x01(\x0b\x32\x1a.snapfaas.syscalls.DcLabelH\x00\x12\x33\n\ngithubRest\x18\x06 \x01(\x0b\x32\x1d.snapfaas.syscalls.GithubRestH\x00\x12+\n\x06invoke\x18\x07 \x01(\x0b\x32\x19.snapfaas.syscalls.InvokeH\x00\x42\t\n\x07syscall*2\n\x08HttpVerb\x12\x07\n\x03GET\x10\x00\x12\x08\n\x04POST\x10\x01\x12\x07\n\x03PUT\x10\x02\x12\n\n\x06\x44\x45LETE\x10\x04\x62\x06proto3')
 
 _HTTPVERB = DESCRIPTOR.enum_types_by_name['HttpVerb']
 HttpVerb = enum_type_wrapper.EnumTypeWrapper(_HTTPVERB)
 GET = 0
 POST = 1
+PUT = 2
+DELETE = 4
 
 
+_INVOKE = DESCRIPTOR.message_types_by_name['Invoke']
+_INVOKERESPONSE = DESCRIPTOR.message_types_by_name['InvokeResponse']
 _CLAUSE = DESCRIPTOR.message_types_by_name['Clause']
 _COMPONENT = DESCRIPTOR.message_types_by_name['Component']
 _DCLABEL = DESCRIPTOR.message_types_by_name['DcLabel']
@@ -36,6 +40,20 @@ _GITHUBREST = DESCRIPTOR.message_types_by_name['GithubRest']
 _GITHUBRESTRESPONSE = DESCRIPTOR.message_types_by_name['GithubRestResponse']
 _GETCURRENTLABEL = DESCRIPTOR.message_types_by_name['GetCurrentLabel']
 _SYSCALL = DESCRIPTOR.message_types_by_name['Syscall']
+Invoke = _reflection.GeneratedProtocolMessageType('Invoke', (_message.Message,), {
+  'DESCRIPTOR' : _INVOKE,
+  '__module__' : 'syscalls_pb2'
+  # @@protoc_insertion_point(class_scope:snapfaas.syscalls.Invoke)
+  })
+_sym_db.RegisterMessage(Invoke)
+
+InvokeResponse = _reflection.GeneratedProtocolMessageType('InvokeResponse', (_message.Message,), {
+  'DESCRIPTOR' : _INVOKERESPONSE,
+  '__module__' : 'syscalls_pb2'
+  # @@protoc_insertion_point(class_scope:snapfaas.syscalls.InvokeResponse)
+  })
+_sym_db.RegisterMessage(InvokeResponse)
+
 Clause = _reflection.GeneratedProtocolMessageType('Clause', (_message.Message,), {
   'DESCRIPTOR' : _CLAUSE,
   '__module__' : 'syscalls_pb2'
@@ -130,32 +148,36 @@ _sym_db.RegisterMessage(Syscall)
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _HTTPVERB._serialized_start=968
-  _HTTPVERB._serialized_end=997
-  _CLAUSE._serialized_start=37
-  _CLAUSE._serialized_end=65
-  _COMPONENT._serialized_start=67
-  _COMPONENT._serialized_end=122
-  _DCLABEL._serialized_start=125
-  _DCLABEL._serialized_end=266
-  _REQUEST._serialized_start=268
-  _REQUEST._serialized_end=294
-  _RESPONSE._serialized_start=296
-  _RESPONSE._serialized_end=323
-  _READKEY._serialized_start=325
-  _READKEY._serialized_end=347
-  _READKEYRESPONSE._serialized_start=349
-  _READKEYRESPONSE._serialized_end=396
-  _WRITEKEY._serialized_start=398
-  _WRITEKEY._serialized_end=436
-  _WRITEKEYRESPONSE._serialized_start=438
-  _WRITEKEYRESPONSE._serialized_end=473
-  _GITHUBREST._serialized_start=475
-  _GITHUBREST._serialized_end=573
-  _GITHUBRESTRESPONSE._serialized_start=575
-  _GITHUBRESTRESPONSE._serialized_end=609
-  _GETCURRENTLABEL._serialized_start=611
-  _GETCURRENTLABEL._serialized_end=628
-  _SYSCALL._serialized_start=631
-  _SYSCALL._serialized_end=966
+  _HTTPVERB._serialized_start=1109
+  _HTTPVERB._serialized_end=1159
+  _INVOKE._serialized_start=37
+  _INVOKE._serialized_end=80
+  _INVOKERESPONSE._serialized_start=82
+  _INVOKERESPONSE._serialized_end=115
+  _CLAUSE._serialized_start=117
+  _CLAUSE._serialized_end=145
+  _COMPONENT._serialized_start=147
+  _COMPONENT._serialized_end=202
+  _DCLABEL._serialized_start=205
+  _DCLABEL._serialized_end=346
+  _REQUEST._serialized_start=348
+  _REQUEST._serialized_end=374
+  _RESPONSE._serialized_start=376
+  _RESPONSE._serialized_end=403
+  _READKEY._serialized_start=405
+  _READKEY._serialized_end=427
+  _READKEYRESPONSE._serialized_start=429
+  _READKEYRESPONSE._serialized_end=476
+  _WRITEKEY._serialized_start=478
+  _WRITEKEY._serialized_end=516
+  _WRITEKEYRESPONSE._serialized_start=518
+  _WRITEKEYRESPONSE._serialized_end=553
+  _GITHUBREST._serialized_start=555
+  _GITHUBREST._serialized_end=653
+  _GITHUBRESTRESPONSE._serialized_start=655
+  _GITHUBRESTRESPONSE._serialized_end=705
+  _GETCURRENTLABEL._serialized_start=707
+  _GETCURRENTLABEL._serialized_end=724
+  _SYSCALL._serialized_start=727
+  _SYSCALL._serialized_end=1107
 # @@protoc_insertion_point(module_scope)

--- a/rootfs/regular/runtimes/python3/workload.py
+++ b/rootfs/regular/runtimes/python3/workload.py
@@ -83,12 +83,25 @@ class Syscall():
         response= self._recv(syscalls_pb2.GithubRestResponse())
         return response
 
-    #def github_rest_put(self, route, body):
-    #    bodyJson = json.dumps(body)
-    #    req = syscalls_pb2.Syscall(githubRest = syscalls_pb2.GithubRest(verb = syscalls_pb2.HttpVerb.PUT, route = route, body = bodyJson))
-    #    self._send(req)
-    #    response= self._recv(syscalls_pb2.GithubRestResponse())
-    #    return response
+    def github_rest_put(self, route, body):
+        bodyJson = json.dumps(body)
+        req = syscalls_pb2.Syscall(githubRest = syscalls_pb2.GithubRest(verb = syscalls_pb2.HttpVerb.PUT, route = route, body = bodyJson))
+        self._send(req)
+        response= self._recv(syscalls_pb2.GithubRestResponse())
+        return response
+
+    def github_rest_delete(self, route, body):
+        bodyJson = json.dumps(body)
+        req = syscalls_pb2.Syscall(githubRest = syscalls_pb2.GithubRest(verb = syscalls_pb2.HttpVerb.DELETE, route = route, body = bodyJson))
+        self._send(req)
+        response= self._recv(syscalls_pb2.GithubRestResponse())
+        return response
+
+    def invoke(self, function, payload):
+        req = syscalls_pb2.Syscall(invoke = syscalls_pb2.Invoke(function = function, payload = payload))
+        self._send(req)
+        response= self._recv(syscalls_pb2.InvokeResponse())
+        return response.success
 
 # send over the boot completion signal
 for i in range(1, os.cpu_count()):

--- a/rootfs/regular/runtimes/python3/workload.py
+++ b/rootfs/regular/runtimes/python3/workload.py
@@ -35,8 +35,12 @@ class Syscall():
 
     def _send(self, req):
         reqData = req.SerializeToString()
-        self.sock.sendall(struct.pack(">I", len(reqData)))
-        self.sock.sendall(reqData)
+        try:
+            self.sock.sendall(struct.pack(">I", len(reqData)))
+            self.sock.sendall(reqData)
+        except:
+            while True:
+                continue
 
     def _recv(self, response):
         data = sock.recv(4, socket.MSG_WAITALL)
@@ -102,6 +106,19 @@ class Syscall():
         self._send(req)
         response= self._recv(syscalls_pb2.InvokeResponse())
         return response.success
+
+    def fswrite(self, path, data):
+        req = syscalls_pb2.Syscall(fsWrite = syscalls_pb2.FSWrite(path = path, data = data))
+        self._send(req)
+        response = self._recv(syscalls_pb2.WriteKeyResponse())
+        return response.success
+
+    def fsread(self, path):
+        req = syscalls_pb2.Syscall(fsRead = syscalls_pb2.FSRead(path = path))
+        self._send(req)
+        response = self._recv(syscalls_pb2.ReadKeyResponse())
+        return response.value
+
 
 # send over the boot completion signal
 for i in range(1, os.cpu_count()):

--- a/rootfs/regular/runtimes/python3/workload.py
+++ b/rootfs/regular/runtimes/python3/workload.py
@@ -19,6 +19,16 @@ hostaddr = (socket.VMADDR_CID_HOST, VSOCKPORT)
 
 app = import_module('workload')
 
+def recvall(sock, n):
+    # Helper function to recv n bytes or return None if EOF is hit
+    data = bytearray()
+    while len(data) < n:
+        packet = sock.recv(n - len(data))
+        if not packet:
+            return None
+        data.extend(packet)
+    return data
+
 class Syscall():
     def __init__(self, sock):
         self.sock = sock
@@ -31,7 +41,7 @@ class Syscall():
     def _recv(self, response):
         data = sock.recv(4, socket.MSG_WAITALL)
         res = struct.unpack(">I", data)
-        responseData = self.sock.recv(res[0], socket.MSG_WAITALL)
+        responseData = recvall(self.sock, res[0])
 
         response.ParseFromString(responseData)
         return response

--- a/rootfs/regular/runtimes/python3/workload.sh
+++ b/rootfs/regular/runtimes/python3/workload.sh
@@ -2,4 +2,7 @@
 
 #/usr/bin/setup-eth0.sh
 #/usr/bin/ioctl
+mkdir -p /tmp
+/bin/mount -t tmpfs -o size=512m tmpfs /tmp
+/bin/mount -r /dev/vdb /srv
 LD_LIBRARY_PATH=/srv/lib PYTHONPATH=/srv:/srv/package python3 /bin/runtime-workload.py


### PR DESCRIPTION
This PR includes changes that add system calls useful for the graderbot (github put/delete and "invoke") as well as initial support for the new labeled filesystem.

There are also some leftover changes from optimizing the base-image for more general use and fixes issues encountered in practice for use in CO316 grading.